### PR TITLE
Swift5 updates

### DIFF
--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,15 +8,21 @@ let package = Package(
     products: [
         .library(
             name: "SendGrid",
-            targets: ["SendGrid"]),
+            targets: ["SendGrid"]
+        )
     ],
     dependencies: [],
     targets: [
         .target(
             name: "SendGrid",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "SendGridTests",
-            dependencies: ["SendGrid"]),
+            dependencies: ["SendGrid"]
+        )
+    ],
+    swiftLanguageVersions: [
+        .v4_2
     ]
 )

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -8,15 +8,21 @@ let package = Package(
     products: [
         .library(
             name: "SendGrid",
-            targets: ["SendGrid"]),
+            targets: ["SendGrid"]
+        )
     ],
     dependencies: [],
     targets: [
         .target(
             name: "SendGrid",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "SendGridTests",
-            dependencies: ["SendGrid"]),
+            dependencies: ["SendGrid"]
+        )
+    ],
+    swiftLanguageVersions: [
+        .v5
     ]
 )

--- a/Sources/SendGrid/API/Models/Stats/Statistic.Metric.swift
+++ b/Sources/SendGrid/API/Models/Stats/Statistic.Metric.swift
@@ -11,7 +11,7 @@ public extension Statistic {
     
     /// The `Statistic.Metric` struct represents the raw statistics for a given
     /// time period.
-    public struct Metric: Decodable {
+    struct Metric: Decodable {
         
         // MARK: - Properties
         //======================================================================
@@ -75,7 +75,7 @@ public extension Statistic {
 public extension Statistic.Metric {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case blocks
         case bounceDrops        = "bounce_drops"
         case bounces

--- a/Sources/SendGrid/API/Models/Stats/Statistic.Sample.swift
+++ b/Sources/SendGrid/API/Models/Stats/Statistic.Sample.swift
@@ -11,7 +11,7 @@ public extension Statistic {
     
     /// The `Statistic.Sample` struct represents a single group of statistics,
     /// with the raw stats being made available via the `metrics` property.
-    public struct Sample: Decodable {
+    struct Sample: Decodable {
         
         /// The raw metrics for each email event type.
         public let metrics: Statistic.Metric

--- a/Sources/SendGrid/API/V3/Mail/Send/Email.Personalization.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Email.Personalization.swift
@@ -97,7 +97,7 @@ open class Personalization: Encodable, EmailHeaderRepresentable, Scheduling {
 public extension Personalization {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case to
         case cc
         case bcc

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Mail/MailSettings.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Mail/MailSettings.swift
@@ -51,7 +51,7 @@ public struct MailSettings: Encodable {
 public extension MailSettings {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         
         case bcc
         case bypassListManagement   = "bypass_list_management"

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Mail/SpamChecker.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Mail/SpamChecker.swift
@@ -68,7 +68,7 @@ public struct SpamChecker: Encodable {
 public extension SpamChecker {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case enable
         case threshold
         case postURL = "post_to_url"

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/ClickTracking.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/ClickTracking.swift
@@ -61,7 +61,7 @@ public struct ClickTracking: Encodable {
 public extension ClickTracking {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case enable
         case enableText = "enable_text"
     }
@@ -91,7 +91,7 @@ public extension ClickTracking {
     /// - plainTextAndHTMLBodies:   If used, links in the HTML body and URLs in
     ///                             the plain text body will be encoded and
     ///                             tracked.
-    public enum Section {
+    enum Section {
         
         /// If used, the setting will be disabled for this email.
         case off

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/GoogleAnalytics.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/GoogleAnalytics.swift
@@ -67,7 +67,7 @@ public struct GoogleAnalytics: Encodable {
 public extension GoogleAnalytics {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case enable
         case source     = "utm_source"
         case medium     = "utm_medium"

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/OpenTracking.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/OpenTracking.swift
@@ -54,7 +54,7 @@ public struct OpenTracking: Encodable {
 public extension OpenTracking {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case enable
         case substitutionTag    = "substitution_tag"
     }
@@ -81,7 +81,7 @@ public extension OpenTracking {
     ///             in the body of your email you can place the text
     ///             "%open_tracking%" at the top. The tag will then be replaced
     ///             with the open tracking pixel.
-    public enum Location {
+    enum Location {
         
         /// Disables open tracking for the email.
         case off

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/SubscriptionTracking.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/SubscriptionTracking.swift
@@ -129,7 +129,7 @@ public struct SubscriptionTracking: Encodable {
 public extension SubscriptionTracking {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case enable
         case text
         case html

--- a/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/TrackingSettings.swift
+++ b/Sources/SendGrid/API/V3/Mail/Send/Settings/Tracking/TrackingSettings.swift
@@ -48,7 +48,7 @@ public struct TrackingSettings: Encodable {
 public extension TrackingSettings {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         
         case clickTracking          = "click_tracking"
         case googleAnalytics        = "ganalytics"
@@ -63,7 +63,7 @@ public extension TrackingSettings {
 extension TrackingSettings: Validatable {
     
     /// Bubbles up the `subscriptionTracking` validation.
-    public func validate() throws {
+   public func validate() throws {
         try self.subscriptionTracking?.validate()
     }
     

--- a/Sources/SendGrid/API/V3/Stats/Statistic.Category.swift
+++ b/Sources/SendGrid/API/V3/Stats/Statistic.Category.swift
@@ -33,7 +33,7 @@ public extension Statistic {
     ///     print(error)
     /// }
     /// ```
-    public class Category: Statistic.Global {
+    class Category: Statistic.Global {
         
         // MARK: - Properties
         //======================================================================

--- a/Sources/SendGrid/API/V3/Stats/Statistic.Global.swift
+++ b/Sources/SendGrid/API/V3/Stats/Statistic.Global.swift
@@ -32,7 +32,7 @@ public extension Statistic {
     ///     print(error)
     /// }
     /// ```
-    public class Global: Request<[Statistic]> {
+    class Global: Request<[Statistic]> {
         
         // MARK: - Properties
         //=========================================================================

--- a/Sources/SendGrid/API/V3/Stats/Statistic.Subuser.swift
+++ b/Sources/SendGrid/API/V3/Stats/Statistic.Subuser.swift
@@ -33,7 +33,7 @@ public extension Statistic {
     ///     print(error)
     /// }
     /// ```
-    public class Subuser: Statistic.Global {
+    class Subuser: Statistic.Global {
         
         // MARK: - Properties
         //======================================================================

--- a/Sources/SendGrid/API/V3/Subuser/Subuser.Get.swift
+++ b/Sources/SendGrid/API/V3/Subuser/Subuser.Get.swift
@@ -31,7 +31,7 @@ public extension Subuser {
     ///     print(error)
     /// }
     /// ```
-    public class Get: Request<[Subuser]> {
+    class Get: Request<[Subuser]> {
         
         // MARK: - Properties
         //=========================================================================

--- a/Sources/SendGrid/API/V3/Suppression/Blocks/Block.Delete.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Blocks/Block.Delete.swift
@@ -47,7 +47,7 @@ public extension Block {
     ///     print(error)
     /// }
     /// ```
-    public class Delete: SuppressionListDeleter<Block>, AutoEncodable {
+    class Delete: SuppressionListDeleter<Block>, AutoEncodable {
         
         // MARK: - Properties
         //======================================================================
@@ -81,13 +81,13 @@ public extension Block {
 public extension Block.Delete {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case deleteAll  = "delete_all"
         case emails
     }
     
     /// :nodoc:
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.deleteAll, forKey: .deleteAll)
         try container.encodeIfPresent(self.emails, forKey: .emails)

--- a/Sources/SendGrid/API/V3/Suppression/Blocks/Block.Get.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Blocks/Block.Get.swift
@@ -81,7 +81,7 @@ public extension Block {
     ///     print(error)
     /// }
     /// ```
-    public class Get: SuppressionListReader<Block> {
+    class Get: SuppressionListReader<Block> {
         
         override init(path: String?, email: String?, start: Date?, end: Date?, page: Page?) {
             super.init(

--- a/Sources/SendGrid/API/V3/Suppression/Bounces/Bounce.Delete.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Bounces/Bounce.Delete.swift
@@ -48,7 +48,7 @@ public extension Bounce {
     ///     print(error)
     /// }
     /// ```
-    public class Delete: SuppressionListDeleter<Bounce>, AutoEncodable {
+    class Delete: SuppressionListDeleter<Bounce>, AutoEncodable {
         
         // MARK: - Properties
         //======================================================================
@@ -82,13 +82,13 @@ public extension Bounce {
 public extension Bounce.Delete {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case deleteAll  = "delete_all"
         case emails
     }
     
     /// :nodoc:
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.deleteAll, forKey: .deleteAll)
         try container.encodeIfPresent(self.emails, forKey: .emails)

--- a/Sources/SendGrid/API/V3/Suppression/Bounces/Bounce.Get.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Bounces/Bounce.Get.swift
@@ -81,7 +81,7 @@ public extension Bounce {
     ///     print(error)
     /// }
     /// ```
-    public class Get: SuppressionListReader<Bounce> {
+    class Get: SuppressionListReader<Bounce> {
         
         override init(path: String?, email: String?, start: Date?, end: Date?, page: Page?) {
             super.init(

--- a/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Add.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Add.swift
@@ -25,7 +25,7 @@ public extension GlobalUnsubscribe {
     ///     print(error)
     /// }
     /// ```
-    public class Add: Request<JSONValue>, AutoEncodable {
+    class Add: Request<JSONValue>, AutoEncodable {
         
         // MARK: - Properties
         //=========================================================================
@@ -87,7 +87,7 @@ public extension GlobalUnsubscribe {
 public extension GlobalUnsubscribe.Add {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case emails = "recipient_emails"
     }
     

--- a/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Delete.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Delete.swift
@@ -26,7 +26,7 @@ public extension GlobalUnsubscribe {
     ///     print(error)
     /// }
     /// ```
-    public class Delete: Request<JSONValue> {
+    class Delete: Request<JSONValue> {
         
         // MARK: - Initializer
         //======================================================================

--- a/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Get.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Global Unsubscribes/GlobalUnsubscribe.Get.swift
@@ -79,7 +79,7 @@ public extension GlobalUnsubscribe {
     ///     print(error)
     /// }
     /// ```
-    public class Get: SuppressionListReader<GlobalUnsubscribe> {
+    class Get: SuppressionListReader<GlobalUnsubscribe> {
         
         override init(path: String?, email: String?, start: Date?, end: Date?, page: Page?) {
             super.init(

--- a/Sources/SendGrid/API/V3/Suppression/Invalid Emails/InvalidEmail.Delete.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Invalid Emails/InvalidEmail.Delete.swift
@@ -48,7 +48,7 @@ public extension InvalidEmail {
     ///     print(error)
     /// }
     /// ```
-    public class Delete: SuppressionListDeleter<InvalidEmail>, AutoEncodable {
+    class Delete: SuppressionListDeleter<InvalidEmail>, AutoEncodable {
         
         // MARK: - Properties
         //======================================================================
@@ -82,13 +82,13 @@ public extension InvalidEmail {
 public extension InvalidEmail.Delete {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case deleteAll  = "delete_all"
         case emails
     }
     
     /// :nodoc:
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.deleteAll, forKey: .deleteAll)
         try container.encodeIfPresent(self.emails, forKey: .emails)

--- a/Sources/SendGrid/API/V3/Suppression/Invalid Emails/InvalidEmail.Get.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Invalid Emails/InvalidEmail.Get.swift
@@ -77,7 +77,7 @@ public extension InvalidEmail {
     ///     print(error)
     /// }
     /// ```
-    public class Get: SuppressionListReader<InvalidEmail> {
+    class Get: SuppressionListReader<InvalidEmail> {
         
         override init(path: String?, email: String?, start: Date?, end: Date?, page: Page?) {
             super.init(

--- a/Sources/SendGrid/API/V3/Suppression/Spam Reports/SpamReport.Delete.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Spam Reports/SpamReport.Delete.swift
@@ -48,7 +48,7 @@ public extension SpamReport {
     ///     print(error)
     /// }
     /// ```
-    public class Delete: SuppressionListDeleter<SpamReport>, AutoEncodable {
+    class Delete: SuppressionListDeleter<SpamReport>, AutoEncodable {
         
         // MARK: - Properties
         //======================================================================
@@ -81,13 +81,13 @@ public extension SpamReport {
 public extension SpamReport.Delete {
     
     /// :nodoc:
-    public enum CodingKeys: String, CodingKey {
+    enum CodingKeys: String, CodingKey {
         case deleteAll  = "delete_all"
         case emails
     }
     
     /// :nodoc:
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(self.deleteAll, forKey: .deleteAll)
         try container.encodeIfPresent(self.emails, forKey: .emails)

--- a/Sources/SendGrid/API/V3/Suppression/Spam Reports/SpamReport.Get.swift
+++ b/Sources/SendGrid/API/V3/Suppression/Spam Reports/SpamReport.Get.swift
@@ -82,7 +82,7 @@ public extension SpamReport {
     ///     print(error)
     /// }
     /// ```
-    public class Get: SuppressionListReader<SpamReport> {
+    class Get: SuppressionListReader<SpamReport> {
         
         override init(path: String?, email: String?, start: Date?, end: Date?, page: Page?) {
             super.init(

--- a/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Address.1.0.0.swift
+++ b/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Address.1.0.0.swift
@@ -10,5 +10,5 @@ import Foundation
 public extension Address {
     /// :nodoc:
     @available(*, deprecated, renamed: "init(email:)")
-    public init(_ email: String) { self.init(email: email, name: nil) }
+    init(_ email: String) { self.init(email: email, name: nil) }
 }

--- a/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Authentication.1.0.0.swift
+++ b/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Authentication.1.0.0.swift
@@ -10,13 +10,13 @@ import Foundation
 public extension Authentication {
     /// :nodoc:
     @available(*, unavailable, message: "use the designated initializer or one of the static functions")
-    public init?(info: [AnyHashable: Any]) { return nil }
+    init?(info: [AnyHashable: Any]) { return nil }
     
     /// :nodoc:
     @available(*, unavailable, message: "use the `value` property to extrapolate the desired value")
-    public var user: String? { return nil }
+    var user: String? { return nil }
     
     /// :nodoc:
     @available(*, unavailable, message: "use the `value` property to extrapolate the desired value")
-    public var key: String { return "" }
+    var key: String { return "" }
 }

--- a/Sources/SendGrid/Deprecations/1.0.0/Deprecations.ClickTracking.1.0.0.swift
+++ b/Sources/SendGrid/Deprecations/1.0.0/Deprecations.ClickTracking.1.0.0.swift
@@ -10,7 +10,7 @@ import Foundation
 public extension ClickTracking {
     /// :nodoc:
     @available(*, deprecated, renamed: "init(section:)")
-    public init(enable: Bool, enablePlainText: Bool? = nil) {
+    init(enable: Bool, enablePlainText: Bool? = nil) {
         self.enable = enable
         self.enableText = enablePlainText
     }

--- a/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Content.1.0.0.swift
+++ b/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Content.1.0.0.swift
@@ -10,13 +10,13 @@ import Foundation
 public extension Content {
     /// :nodoc:
     @available(*, deprecated, renamed: "plainText(body:)")
-    public static func plainTextContent(_ value: String) -> Content { return .plainText(body: value) }
+    static func plainTextContent(_ value: String) -> Content { return .plainText(body: value) }
     
     /// :nodoc:
     @available(*, deprecated, renamed: "html(body:)")
-    public static func htmlContent(_ value: String) -> Content { return .html(body: value) }
+    static func htmlContent(_ value: String) -> Content { return .html(body: value) }
     
     /// :nodoc:
     @available(*, deprecated, renamed: "emailBody(plain:html:)")
-    public static func emailContent(plain: String, html: String) -> [Content] { return Content.emailBody(plain: plain, html: html) }
+    static func emailContent(plain: String, html: String) -> [Content] { return Content.emailBody(plain: plain, html: html) }
 }

--- a/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Request.1.0.0.swift
+++ b/Sources/SendGrid/Deprecations/1.0.0/Deprecations.Request.1.0.0.swift
@@ -10,7 +10,7 @@ import Foundation
 public extension Request {
     /// :nodoc:
     @available(*, unavailable, message: "use the `generateUrlRequest` method instead.")
-    public func request(for session: Session, onBehalfOf: String?) throws -> URLRequest {
+    func request(for session: Session, onBehalfOf: String?) throws -> URLRequest {
         throw Exception.Global.methodUnavailable(type(of: self), "request(for:onBehalfOf:)")
     }
 }

--- a/Sources/SendGrid/Enums/Statistic.Aggregation.swift
+++ b/Sources/SendGrid/Enums/Statistic.Aggregation.swift
@@ -14,7 +14,7 @@ public extension Statistic {
     /// - day:      Statistic aggregated by day.
     /// - week:     Statistics aggregated by week.
     /// - month:    Statistics aggregated by month.
-    public enum Aggregation: String, Decodable {
+    enum Aggregation: String, Decodable {
         
         /// Statistics aggregated by day.
         case day

--- a/Sources/SendGrid/Enums/Statistic.Dimension.swift
+++ b/Sources/SendGrid/Enums/Statistic.Dimension.swift
@@ -14,7 +14,7 @@ public extension Statistic {
     ///
     /// - category: Represents statistics grouped by category.
     /// - subuser:  Represents statistics grouped by subuser.
-    public enum Dimension: String, Decodable {
+    enum Dimension: String, Decodable {
         
         /// Represents statistics grouped by category.
         case category

--- a/Sources/SendGrid/Errors/Exception+Authentication.swift
+++ b/Sources/SendGrid/Errors/Exception+Authentication.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.Authentication` enum contains all the errors thrown by
     /// `Authentication`.
-    public enum Authentication: Error, CustomStringConvertible {
+    enum Authentication: Error, CustomStringConvertible {
 
         // MARK: - Cases
         //======================================================================

--- a/Sources/SendGrid/Errors/Exception+ContentType.swift
+++ b/Sources/SendGrid/Errors/Exception+ContentType.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.ContentType` enum contains all the errors thrown by
     /// `ContentType`.
-    public enum ContentType: Error, CustomStringConvertible {
+    enum ContentType: Error, CustomStringConvertible {
         
         // MARK: - Cases
         //======================================================================

--- a/Sources/SendGrid/Errors/Exception+Global.swift
+++ b/Sources/SendGrid/Errors/Exception+Global.swift
@@ -10,7 +10,7 @@ import Foundation
 public extension Exception {
     
     /// The `Exception.Global` struct contains global errors that can be thrown.
-    public enum Global: Error, CustomStringConvertible {
+    enum Global: Error, CustomStringConvertible {
         
         // MARK: - Cases
         //=========================================================================

--- a/Sources/SendGrid/Errors/Exception+Mail.swift
+++ b/Sources/SendGrid/Errors/Exception+Mail.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.Mail` enum contains all the errors thrown for the mail
     /// send API.
-    public enum Mail: Error, CustomStringConvertible {
+    enum Mail: Error, CustomStringConvertible {
         
         // MARK: - Cases
         //======================================================================

--- a/Sources/SendGrid/Errors/Exception+Request.swift
+++ b/Sources/SendGrid/Errors/Exception+Request.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.Request` enum contains all the errors thrown by
     /// `Request`.
-    public enum Request: Error, CustomStringConvertible {
+    enum Request: Error, CustomStringConvertible {
         
         // MARK: - Cases
         //======================================================================

--- a/Sources/SendGrid/Errors/Exception+Session.swift
+++ b/Sources/SendGrid/Errors/Exception+Session.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.Session` enum contains all the errors thrown when 
     /// attempting to build an HTTP request.
-    public enum Session: Error, CustomStringConvertible {
+    enum Session: Error, CustomStringConvertible {
         
         // MARK: - Cases
         //======================================================================

--- a/Sources/SendGrid/Errors/Exception+Statistic.swift
+++ b/Sources/SendGrid/Errors/Exception+Statistic.swift
@@ -11,7 +11,7 @@ public extension Exception {
     
     /// The `Exception.Statistic` enum represents all the errors that can be thrown
     /// on the statistics calls.
-    public enum Statistic: Error, CustomStringConvertible {
+    enum Statistic: Error, CustomStringConvertible {
         
         /// Thrown if the end date is before the start date.
         case invalidEndDate

--- a/Sources/SendGrid/Protocols/EmailHeaderRepresentable.swift
+++ b/Sources/SendGrid/Protocols/EmailHeaderRepresentable.swift
@@ -56,7 +56,11 @@ public extension EmailHeaderRepresentable {
             "bcc"
         ]
         for (key, _) in head {
+            #if swift(>=5.0)
+            guard reserved.firstIndex(of: key.lowercased()) == nil else { throw Exception.Mail.headerNotAllowed(key) }
+            #else
             guard reserved.index(of: key.lowercased()) == nil else { throw Exception.Mail.headerNotAllowed(key) }
+            #endif
             let regex = try NSRegularExpression(pattern: "(\\s)", options: [.caseInsensitive, .anchorsMatchLines])
             guard regex.numberOfMatches(in: key, options: [], range: NSMakeRange(0, key.count)) == 0 else {
                 throw Exception.Mail.malformedHeader(key)

--- a/Sources/SendGrid/Protocols/EmailHeaderRepresentable.swift
+++ b/Sources/SendGrid/Protocols/EmailHeaderRepresentable.swift
@@ -39,7 +39,7 @@ public extension EmailHeaderRepresentable {
     /// - Reply-To
     /// - CC
     /// - BCC
-    public func validateHeaders() throws {
+    func validateHeaders() throws {
         guard let head = self.headers else { return }
         let reserved: [String] = [
             "x-sg-id",

--- a/Sources/SendGrid/Protocols/Scheduling.swift
+++ b/Sources/SendGrid/Protocols/Scheduling.swift
@@ -22,7 +22,7 @@ public extension Scheduling {
     
     /// The default implementation validates that the date is less than 72 hours
     /// in the future.
-    public func validateSendAt() throws {
+    func validateSendAt() throws {
         if let date = self.sendAt {
             guard date.timeIntervalSinceNow <= Constants.ScheduleLimit else { throw Exception.Mail.invalidScheduleDate }
         }

--- a/Tests/SendGridTests/API/V3/Mail/Send/AttachmentTests.swift
+++ b/Tests/SendGridTests/API/V3/Mail/Send/AttachmentTests.swift
@@ -15,7 +15,11 @@ class AttachmentTests: XCTestCase, EncodingTester {
     static let dotBase64: String = "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=="
     
     func testEncoding() {
+        #if swift(>=5.0)
+        let data = Data(AttachmentTests.redDotBytes)
+        #else
         let data = Data(bytes: AttachmentTests.redDotBytes)
+        #endif
         let minimalAttachment = Attachment(filename: "red.png", content: data)
         XCTAssertEncodedObject(minimalAttachment, equals: [
             "content": AttachmentTests.dotBase64,
@@ -36,7 +40,11 @@ class AttachmentTests: XCTestCase, EncodingTester {
     }
     
     func testInitialization() {
+        #if swift(>=5.0)
+        let data = Data(AttachmentTests.redDotBytes)
+        #else
         let data = Data(bytes: AttachmentTests.redDotBytes)
+        #endif
         let basic = Attachment(filename: "dot.png", content: data)
         XCTAssertEqual(basic.filename, "dot.png")
         XCTAssertEqual(basic.disposition, ContentDisposition.attachment)
@@ -51,7 +59,11 @@ class AttachmentTests: XCTestCase, EncodingTester {
     }
     
     func testValidation() {
+        #if swift(>=5.0)
+        let image = Data(AttachmentTests.redDotBytes)
+        #else
         let image = Data(bytes: AttachmentTests.redDotBytes)
+        #endif
         // Validation should pass with a valid content type.
         let good1 = Attachment(filename: "dot.png", content: image, disposition: .attachment, type: .png, contentID: nil)
         XCTAssertNoThrow(try good1.validate())

--- a/Tests/SendGridTests/API/V3/Mail/Send/EmailTests.swift
+++ b/Tests/SendGridTests/API/V3/Mail/Send/EmailTests.swift
@@ -97,7 +97,11 @@ class EmailTests: XCTestCase, EncodingTester {
             subject: "Root Subject"
         )
         max.replyTo = Address(email: "reply_to@example.none")
+        #if swift(>=5.0)
+        let data = Data(AttachmentTests.redDotBytes)
+        #else
         let data = Data(bytes: AttachmentTests.redDotBytes)
+        #endif
         max.attachments = [Attachment(filename: "red.png", content: data)]
         max.templateID = "1334949C-CE58-4A21-A633-47638EFA358A"
         max.sections = [


### PR DESCRIPTION
- Updated manifests for Swift versions 4.1 / 4.2 / 5.0
- Trivial updates to remove warnings during Swift 5.0 compilation

Clean tests with 4.1.3 / 4.2.4 / 5.0 on Linux.
Clean tests with 4.1.3 / 4.2.3 / 5.0 on MacOS.

Usage of compactMap() prevents compilation < 4.1