### PR TITLE
Expose Exception.APIResponse

### DIFF
--- a/Sources/SendGrid/Errors/Exception+API.swift
+++ b/Sources/SendGrid/Errors/Exception+API.swift
@@ -8,10 +8,10 @@ public extension Exception {
     /// API call that is indicating an error occurred.
     struct APIResponse: Error, Codable {
         /// The list of error messages.
-        let errors: [APIMessage]
+        public let errors: [APIMessage]
         
         /// The original `HTTPURLResponse` from the HTTP request.
-        var httpResponse: HTTPURLResponse! { self._httpResponse }
+        public var httpResponse: HTTPURLResponse! { self._httpResponse }
         
         /// :nodoc:
         internal var _httpResponse: HTTPURLResponse!
@@ -26,12 +26,12 @@ public extension Exception {
     /// returned from the API.
     struct APIMessage: Codable {
         /// The description of the error.
-        let message: String
+        public let message: String
         
         /// The field in the request that the error is referencing.
-        let field: String?
+        public let field: String?
         
         /// A description on how to solve the error.
-        let help: String?
+        public let help: String?
     }
 }


### PR DESCRIPTION
Currently the properties are implicitly internal and cannot be accessed by any application using sendgrid-swift